### PR TITLE
develop-ph8c8

### DIFF
--- a/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/00_person.sql
+++ b/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/00_person.sql
@@ -22,7 +22,7 @@ SELECT
     {% if site in ['mu', 'mu-id'] %}
         demographic.patid
     {% elif site == 'gpc' %}
-        demographic.person_num
+        demographic.patient_num
     {% else %}
         demographic.patid
     {% endif %} ::INTEGER AS person_id,

--- a/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/01_death.sql
+++ b/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/01_death.sql
@@ -121,5 +121,5 @@ LEFT JOIN {{ cdm_db }}.{{ vocabulary }}.concept c_icd10
 LEFT JOIN {{ cdm_db }}.{{ vocabulary }}.concept c_snomed 
     ON dc.death_cause = c_snomed.concept_code
     AND c_snomed.vocabulary_id = 'SNOMED'
-    AND dc.death_cause_code = 'SM'
-where d.death_date is not null;
+    AND dc.death_cause_code = 'SM';
+--where d.death_date is not null;

--- a/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/01_death.sql
+++ b/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/01_death.sql
@@ -1,6 +1,6 @@
 CREATE TABLE  {{ cdm_db }}.{{ cdm_schema }}.death (
     person_id integer NOT NULL, --TODO: this should be not nullable,11 out of 2 million (they also have null date)
-    death_date date NOT NULL,
+    death_date date NOT NULL, --TODO: this should be not nullable. currently filtering out null death dates
     death_datetime TIMESTAMP NULL,
     death_type_concept_id integer NULL,
     cause_concept_id integer NULL,

--- a/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/01_death.sql
+++ b/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/01_death.sql
@@ -1,6 +1,6 @@
 CREATE TABLE  {{ cdm_db }}.{{ cdm_schema }}.death (
-    person_id integer NOT NULL,
-    death_date date NOT NULL,
+    person_id integer NULL, --TODO: this should be not nullable, 90k out of 2 million
+    death_date date NULL, --TODO: this should be not nullable, 11 out of 2 million (they also have null date)
     death_datetime TIMESTAMP NULL,
     death_type_concept_id integer NULL,
     cause_concept_id integer NULL,

--- a/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/01_death.sql
+++ b/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/01_death.sql
@@ -1,6 +1,6 @@
 CREATE TABLE  {{ cdm_db }}.{{ cdm_schema }}.death (
-    person_id integer NULL, --TODO: this should be not nullable, 90k out of 2 million
-    death_date date NULL, --TODO: this should be not nullable, 11 out of 2 million (they also have null date)
+    person_id integer NOT NULL, --TODO: this should be not nullable,11 out of 2 million (they also have null date)
+    death_date date NOT NULL, 
     death_datetime TIMESTAMP NULL,
     death_type_concept_id integer NULL,
     cause_concept_id integer NULL,
@@ -121,4 +121,5 @@ LEFT JOIN {{ cdm_db }}.{{ vocabulary }}.concept c_icd10
 LEFT JOIN {{ cdm_db }}.{{ vocabulary }}.concept c_snomed 
     ON dc.death_cause = c_snomed.concept_code
     AND c_snomed.vocabulary_id = 'SNOMED'
-    AND dc.death_cause_code = 'SM';
+    AND dc.death_cause_code = 'SM'
+where d.death_date is not null;

--- a/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/01_death.sql
+++ b/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/01_death.sql
@@ -1,6 +1,6 @@
 CREATE TABLE  {{ cdm_db }}.{{ cdm_schema }}.death (
     person_id integer NOT NULL, --TODO: this should be not nullable,11 out of 2 million (they also have null date)
-    death_date date NOT NULL, 
+    death_date date NOT NULL,
     death_datetime TIMESTAMP NULL,
     death_type_concept_id integer NULL,
     cause_concept_id integer NULL,

--- a/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/05_visit_occurrence.sql
+++ b/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/05_visit_occurrence.sql
@@ -23,7 +23,7 @@ SELECT
         enc.patid::INTEGER AS person_id,
     {% elif site == 'gpc' %}
         enc.encounter_num::INTEGER AS visit_occurrence_id,
-        enc.person_num::INTEGER AS person_id,
+        enc.patient_num::INTEGER AS person_id,
     {% else %}
         enc.encounterid::INTEGER AS visit_occurrence_id,
         enc.patid::INTEGER AS person_id,
@@ -47,7 +47,7 @@ SELECT
     as_map.source_concept_id::INTEGER AS admitted_from_concept_id,
     enc.raw_admitting_source::VARCHAR(50) AS admitted_from_source_value,
     ds_map.source_concept_id::INTEGER AS discharged_to_concept_id,
-    enc.raw_discharge_status::VARCHAR(50) AS discharged_to_source_value,
+    substr(enc.raw_discharge_status,0,50)::VARCHAR(50) AS discharged_to_source_value,
     NULL::INTEGER AS preceding_visit_occurrence_id
 FROM {{ pcornet_db }}.{{ pcornet_schema }}.{{ encounter_table }} enc
 -- Mapping admitted_from

--- a/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/06_visit_detail.sql
+++ b/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/06_visit_detail.sql
@@ -25,7 +25,7 @@ SELECT
         enc.patid::INTEGER AS person_id,
     {% elif site == 'gpc' %}
         enc.encounter_num::INTEGER AS visit_detail_id,
-        enc.person_num::INTEGER AS person_id,
+        enc.patient_num::INTEGER AS person_id,
     {% else %}
         enc.encounterid::INTEGER AS visit_detail_id,
         enc.patid::INTEGER AS person_id,
@@ -48,12 +48,12 @@ SELECT
     0                                     AS visit_detail_source_concept_id,
     as_map.source_concept_id::INTEGER     AS admitted_from_concept_id, 
     enc.raw_admitting_source::VARCHAR(50) AS admitted_from_source_value,
-    enc.raw_discharge_status::VARCHAR(50) AS discharged_to_source_value,
+    substr(enc.raw_discharge_status,0,50)::VARCHAR(50) AS discharged_to_source_value,
     ds_map.source_concept_id::INTEGER     AS discharged_to_concept_id,
     {% if site in ['mu', 'mu-id'] %}
         lag(enc.encounterid) OVER (PARTITION BY enc.patid ORDER BY enc.admit_date) AS preceding_visit_detail_id,
     {% elif site == 'gpc' %}
-        lag(enc.encounter_num) OVER (PARTITION BY enc.person_num ORDER BY enc.admit_date) AS preceding_visit_detail_id,
+        lag(enc.encounter_num) OVER (PARTITION BY enc.patient_num ORDER BY enc.admit_date) AS preceding_visit_detail_id,
     {% else %}
         lag(enc.encounterid) OVER (PARTITION BY enc.patid ORDER BY enc.admit_date) AS preceding_visit_detail_id,
     {% endif %}

--- a/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/07_procedure_occurrence.sql
+++ b/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/07_procedure_occurrence.sql
@@ -22,8 +22,8 @@ SELECT
         ROW_NUMBER() OVER (ORDER BY procedures.patid)::INTEGER AS procedure_occurrence_id,
         procedures.patid::INTEGER AS person_id,
     {% elif site == 'gpc' %}
-        ROW_NUMBER() OVER (ORDER BY procedures.person_num)::INTEGER AS procedure_occurrence_id,
-        procedures.person_num::INTEGER AS person_id,
+        ROW_NUMBER() OVER (ORDER BY procedures.patient_num)::INTEGER AS procedure_occurrence_id,
+        procedures.patient_num::INTEGER AS person_id,
     {% else %}
         ROW_NUMBER() OVER (ORDER BY procedures.patid)::INTEGER AS procedure_occurrence_id,
         procedures.patid::INTEGER AS person_id,

--- a/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/07_procedure_occurrence.sql
+++ b/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/07_procedure_occurrence.sql
@@ -61,10 +61,15 @@ JOIN {{ cdm_db }}.{{ vocabulary }}.source_to_source_vocab_map srctosrcvm
         CASE 
             WHEN procedures.px_type = '09' THEN 'ICD9Proc'
             WHEN procedures.px_type = '10' THEN 'ICD10PCS'
-            WHEN procedures.px_type = 'CH' THEN 
-                CASE 
-                    WHEN procedures.raw_px_type = 'CPT4' THEN 'CPT4'
-                    ELSE 'HCPCS'
+            WHEN procedures.px_type = 'CH' THEN
+                CASE
+                    WHEN (
+                        rlike(procedures.px,'\\D.*')
+                        and length(procedures.px) in (3,5)
+                        and procedures.px not in ('V-CPT','V-SRC')
+                        or procedures.px in ('KM','KN','P0')
+                        )       THEN 'HCPCS'
+                    ELSE 'CPT4'
                 END
         END
     AND srctosrcvm.source_domain_id = 'Procedure'

--- a/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/08_condition_occurrence.sql
+++ b/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/08_condition_occurrence.sql
@@ -26,8 +26,8 @@ SELECT
           ROW_NUMBER() OVER (ORDER BY diagnosis.patid)::INTEGER AS condition_occurrence_id,
           diagnosis.patid::INTEGER AS person_id,
      {% elif site == 'gpc' %}
-          ROW_NUMBER() OVER (ORDER BY diagnosis.person_num)::INTEGER AS condition_occurrence_id,
-          diagnosis.person_num::INTEGER AS person_id,
+          ROW_NUMBER() OVER (ORDER BY diagnosis.patient_num)::INTEGER AS condition_occurrence_id,
+          diagnosis.patient_num::INTEGER AS person_id,
      {% else %}
           ROW_NUMBER() OVER (ORDER BY diagnosis.patid)::INTEGER AS condition_occurrence_id,
           diagnosis.patid::INTEGER AS person_id,
@@ -98,8 +98,8 @@ SELECT
           ROW_NUMBER() OVER (ORDER BY condition.patid)::INTEGER AS condition_occurrence_id,
           condition.patid::INTEGER AS person_id,
      {% elif site == 'gpc' %}
-          ROW_NUMBER() OVER (ORDER BY condition.person_num)::INTEGER AS condition_occurrence_id,
-          condition.person_num::INTEGER AS person_id,
+          ROW_NUMBER() OVER (ORDER BY condition.patient_num)::INTEGER AS condition_occurrence_id,
+          condition.patient_num::INTEGER AS person_id,
      {% else %}
           ROW_NUMBER() OVER (ORDER BY condition.patid)::INTEGER AS condition_occurrence_id,
           condition.patid::INTEGER AS person_id,

--- a/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/08_condition_occurrence.sql
+++ b/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/08_condition_occurrence.sql
@@ -137,4 +137,5 @@ LEFT JOIN {{ cdm_db }}.{{ vocabulary }}.source_to_standard_vocab_map srctostdvm
      AND srctostdvm.target_domain_id = srctosrcvm.source_domain_id 
      AND srctostdvm.source_vocabulary_id = srctosrcvm.source_vocabulary_id
      AND srctostdvm.target_standard_concept = 'S'
-     AND srctostdvm.target_invalid_reason IS NULL;
+     AND srctostdvm.target_invalid_reason IS NULL
+WHERE condition.report_date IS NOT NULL;

--- a/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/10_observation.sql
+++ b/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/10_observation.sql
@@ -26,7 +26,7 @@ SELECT DISTINCT
     {% if site in ['mu', 'mu-id'] %}
         enc.patid::INTEGER AS person_id,
     {% elif site == 'gpc' %}
-        enc.person_num::INTEGER AS person_id,
+        enc.patient_num::INTEGER AS person_id,
     {% else %}
         enc.patid::INTEGER AS person_id,
     {% endif %}

--- a/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/10_observation.sql
+++ b/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/10_observation.sql
@@ -88,3 +88,4 @@ LEFT JOIN {{ cdm_db }}.{{ vocabulary }}.concept msdrg
     AND msdrg.concept_class_id = 'MS-DRG'
     AND msdrg.invalid_reason IS NULL
 WHERE enc.drg IS NOT NULL;
+--and rlike(enc.providerid, '\\d{1,}');

--- a/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/10_observation.sql
+++ b/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/10_observation.sql
@@ -56,7 +56,12 @@ SELECT DISTINCT
     END AS value_as_concept_id,
     4269228 AS qualifier_concept_id,
     NULL AS unit_concept_id,
-    enc.providerid AS provider_id,
+    CASE
+        WHEN rlike(enc.providerid, '\\d{1,}')
+            THEN enc.providerid
+        ELSE NULL
+    END AS provider_id,
+    --enc.providerid AS provider_id,
     {% if site in ['mu', 'mu-id'] %}
         enc.encounterid::INTEGER AS visit_occurrence_id,
     {% elif site == 'gpc' %}
@@ -88,4 +93,3 @@ LEFT JOIN {{ cdm_db }}.{{ vocabulary }}.concept msdrg
     AND msdrg.concept_class_id = 'MS-DRG'
     AND msdrg.invalid_reason IS NULL
 WHERE enc.drg IS NOT NULL;
---and rlike(enc.providerid, '\\d{1,}');

--- a/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/11_observation_period.sql
+++ b/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/11_observation_period.sql
@@ -17,4 +17,6 @@ SELECT
     enrl.enr_start_date::DATE AS observation_period_start_date,
     enrl.enr_end_date::DATE AS observation_period_end_date,
     44814722::INTEGER AS period_type_concept_id
-FROM {{ pcornet_db }}.{{ pcornet_schema }}.{{ enrollment_table }} enrl;
+FROM {{ pcornet_db }}.{{ pcornet_schema }}.{{ enrollment_table }} enrl
+where enrl.enr_end_date is not null
+;

--- a/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/11_observation_period.sql
+++ b/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/11_observation_period.sql
@@ -10,7 +10,7 @@ SELECT
     {% if site in ['mu', 'mu-id'] %}
         enrl.patid
     {% elif site == 'gpc' %}
-        enrl.person_num
+        enrl.patient_num
     {% else %}
         enrl.patid
     {% endif %} ::INTEGER AS person_id,

--- a/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/12_measurement.sql
+++ b/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/12_measurement.sql
@@ -34,7 +34,7 @@ SELECT DISTINCT
     {% if site in ['mu', 'mu-id'] %}
         , lab.patid::INTEGER AS person_id
     {% elif site == 'gpc' %}
-        , lab.person_num::INTEGER AS person_id
+        , lab.patient_num::INTEGER AS person_id
     {% else %}
         , lab.patid::INTEGER AS person_id
     {% endif %}

--- a/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/12_measurement.sql
+++ b/OMOP_ON_PCORNET_CDM/SCRIPTS/omop_cdm/12_measurement.sql
@@ -90,3 +90,4 @@ LEFT JOIN {{ cdm_db }}.{{ vocabulary }}.concept u
     ON lab.result_unit = u.concept_code
 LEFT JOIN {{ cdm_db }}.{{ vocabulary }}.concept c_result
     ON lab.lab_result_source = c_result.concept_code;
+--where lab.result_date is not null;

--- a/OMOP_ON_PCORNET_CDM/airflow/dags/dag_data_refresh.py
+++ b/OMOP_ON_PCORNET_CDM/airflow/dags/dag_data_refresh.py
@@ -26,8 +26,8 @@ with DAG(
     tags=["omop_data_refresh"],
 ) as dag:
     # Load environment variables and set ENVIRONMENT as enum: 'sandbox', 'dev', or 'prod'
-    ENVIRONMENT = 'prod' # ['sandbox', 'dev', 'prod']
-    ACCOUNT = 'identified' # ['deidentified', 'identified']
+    ENVIRONMENT = 'gpc' # ['sandbox', 'dev', 'prod']
+    ACCOUNT = 'deidentified' # ['deidentified', 'identified']
     env_path = f"/opt/airflow/env/{ACCOUNT}/{ENVIRONMENT}/.env"
     
     # Extract variables from args

--- a/OMOP_ON_PCORNET_CDM/airflow/dags/dag_init.py
+++ b/OMOP_ON_PCORNET_CDM/airflow/dags/dag_init.py
@@ -27,7 +27,7 @@ with DAG(
 ) as dag:
     
     # Load environment variables and set ENVIRONMENT as enum: 'sandbox', 'dev', or 'prod'
-    ENVIRONMENT = 'dev' # ['sandbox', 'dev', 'prod']
+    ENVIRONMENT = 'gpc' # ['sandbox', 'dev', 'prod']
     ACCOUNT = 'deidentified' # ['deidentified', 'identified']
     env_path = f"/opt/airflow/env/{ACCOUNT}/{ENVIRONMENT}/.env"
 

--- a/OMOP_ON_PCORNET_CDM/docker-compose.yaml
+++ b/OMOP_ON_PCORNET_CDM/docker-compose.yaml
@@ -288,10 +288,10 @@ services:
         echo
         ls -la /opt/airflow/{logs,dags,plugins,config}
         echo
-        # echo "Creating datasource de-identified connections..."
-        # bash /opt/airflow/env/deidentified/connections.sh
+        echo "Creating datasource de-identified connections..."
+        bash /opt/airflow/env/deidentified/connections.sh
         # echo "Creating datasource identified connections..."
-        # bash /opt/airflow/env/identified/connections.sh
+        #bash /opt/airflow/env/identified/connections.sh
 
     # yamllint enable rule:line-length
     environment:


### PR DESCRIPTION
changed person_num to patient_num when appropriate

issues lie within 01,10, and 12 where changes are either filtering out null columns values that cant be null or ensuring proper data type by making null nonrequired,  non-conforming values

since we fixed issue in pcornet procedure, change in 07 may be redundant. it still will catch some incorrect hcpcs/cpt4 codes though


be aware of care site differences in 05 and 06
